### PR TITLE
chore: remove unused React default import

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef, useState } from "react";
+import { useRef, useState } from "react";
 import Brain3D from "../components/Brain3D"; // relative path
 
 export default function Page() {


### PR DESCRIPTION
## Summary
- remove React default import from page and rely on hooks only

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Syntax Error in components/Brain3D.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689fa0d60a588327acc50511845cd975